### PR TITLE
Added possibility to specify if brightness characteristic is available

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ Here is an homebridge's `config.json` with the minimal valid configuration:
 ````
 
 Beware, I'm a lazy ass!  
-These three parameters are not checked!  
+These four parameters are not checked!  
 (`get_brightness_url`, `set_brightness_url`, `get_on_off_url`, `set_on_off_url`)  
 If you forgot to write them in your accessory, the module will crash.
 
@@ -74,6 +74,8 @@ Here are them all with their default values.
 
 ````
 {
+    "is_dimmable": "true"
+
     "get_on_off_expected_response_code": "GET",
     "set_on_off_expected_response_code": "POST",
     "get_brightness_expected_response_code": "GET",

--- a/index.js
+++ b/index.js
@@ -18,6 +18,9 @@ function MinimalisticHttpLightbulbBrightness(log, config) {
     this.get_brightness_url = config.get_brightness_url;
     this.set_brightness_url  = config.set_brightness_url;
 
+    // Optional parameters: lightbulb properties
+    this.is_dimmable = config.is_dimmable != "false";
+
     // Optional parameters: HTTP methods
     this.get_on_off_method = config.get_on_off_method || 'GET';
     this.set_on_off_method  = config.set_on_off_method  || 'POST';
@@ -44,7 +47,9 @@ function MinimalisticHttpLightbulbBrightness(log, config) {
     this.get_brightness_callbacks = [];
 
     // Initializing things
-    this.start_brightness_polling();
+    if (this.is_dimmable) {
+        this.start_brightness_polling();
+    }
     this.start_on_off_polling();
     this.init_service();
 }
@@ -57,10 +62,12 @@ MinimalisticHttpLightbulbBrightness.prototype.init_service = function() {
     }.bind(this));
     this.service.getCharacteristic(Characteristic.On).on('set', this.set_on_off.bind(this));
 
-    this.service.getCharacteristic(Characteristic.Brightness).on('get', function(callback) {
-        this.get_brightness_callbacks.push(callback);
-    }.bind(this));
-    this.service.getCharacteristic(Characteristic.Brightness).on('set', this.set_brightness.bind(this));
+    if (this.is_dimmable) {
+        this.service.getCharacteristic(Characteristic.Brightness).on('get', function(callback) {
+	        this.get_brightness_callbacks.push(callback);
+	    }.bind(this));
+	    this.service.getCharacteristic(Characteristic.Brightness).on('set', this.set_brightness.bind(this));
+    }
 };
 
 MinimalisticHttpLightbulbBrightness.prototype.start_on_off_polling = function() {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "homebridge-minimal-http-lightbulb-brightness",
   "description": "Minimalistic HTTP lightbulb-brightness management *that supports brightness percentages* for diy-ish projects.",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "repository": {
     "type": "git",
     "url": "git://github.com/Nicnl/homebridge-minimal-http-lightbulb-brightness.git"


### PR DESCRIPTION
By default, brightness remained available. When you configure the accessory with `is_dimmable = 'false'` it will work just as an on/off switch.